### PR TITLE
Make tenant finding strategy customizable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## [Unreleased]
 
+## [1.1.0] - 2021-10-07
+
+- Make tenant finding strategy customizable
+  - Override `find_current_tenant_account` in controller
+
 ## [1.0.5] - 2021-10-06
 
 - Fix an error caused by call `helper_method` on ActionController::API

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Keep your data secure with multi-tenant-support. Prevent most ActiveRecord CRUD 
 - Prevent most ActiveRecord CRUD methods from acting across tenants.
 - Support Row-level Multitenancy
 - Build on ActiveSupport::CurrentAttributes offered by rails
-- Auto set current tenant through subdomain and domain in controller
+- Auto set current tenant through subdomain and domain in controller (overrideable)
 - Support ActiveJob and Sidekiq
 
 
@@ -219,7 +219,7 @@ Below are the behaviour of all ActiveRecord CRUD methods under abvove scenarios:
 
 ## Usage
 
-#### Get current 
+### Get current 
 
 Get current tenant through:
 
@@ -227,7 +227,7 @@ Get current tenant through:
 MultiTenantSupport.current_tenant
 ```
 
-#### Switch tenant
+### Switch tenant
 
 You can switch to another tenant temporary through:
 
@@ -237,7 +237,7 @@ MultiTenantSupport.under_tenant amazon do
 end
 ```
 
-#### Disallow read across tenant by default
+### Disallow read across tenant by default
 
 This gem disallow read across tenant by default. You can check current state through:
 
@@ -245,7 +245,7 @@ This gem disallow read across tenant by default. You can check current state thr
 MultiTenantSupport.disallow_read_across_tenant?
 ```
 
-#### Allow read across tenant for super admin
+### Allow read across tenant for super admin
 
 You can turn on the permission to read records across tenant through: 
 
@@ -260,7 +260,7 @@ end
 
 You can put it in a before action in SuperAdmin's controllers
 
-#### Disallow modify records tenant
+### Disallow modify records tenant
 
 This gem disallow modify record across tenant no matter you are super admin or not.
 
@@ -274,23 +274,41 @@ If `MultiTenantSupport.current_tenant` exist, you can only modify those records 
 
 If `MultiTenantSupport.current_tenant` is missing, you cannot modify or create any tenanted records.
 
-#### Set current tenant acccount in controller by default
+### Set current tenant acccount in controller by default
 
 This gem has set a before action `set_current_tenant_account` on ActionController. It search tenant by subdomain or domain. Do remember to `skip_before_action :set_current_tenant_account` in super admin controllers.
 
 Feel free to override it, if the finder behaviour is not what you want.
 
-#### upsert_all
+### Override current tenant finder method if domain/subdomain is not the way you want
+
+You can override `find_current_tenant_account` in any controller with your own tenant finding strategy. Just make sure this method return the tenat account record or nil.
+
+For example, say you only want to find tenant with domain not subdomain. It's very simple:
+
+```ruby
+class ApplicationController < ActionController::Base
+  private
+
+  def find_current_tenant_account
+    Account.find_by(domain: request.domain)
+  end
+end
+```
+
+Then your tenant finding strategy has changed from domain/subdomain to domain only.
+
+### upsert_all
 
 Currently, we don't have a good way to protect this method. So please use `upser_all` carefully.
 
-#### Unscoped
+### Unscoped
 
 This gem has override `unscoped` to prevent the default tenant scope be scoped out. But if you really want to scope out the default tenant scope, you can use `unscope_tenant`.
 
 ## Code Example
 
-#### Database Schema
+### Database Schema
 
 ```ruby
 create_table "accounts", force: :cascade do |t|

--- a/lib/multi_tenant_support/concern/controller_concern.rb
+++ b/lib/multi_tenant_support/concern/controller_concern.rb
@@ -15,12 +15,16 @@ module MultiTenantSupport
       end
 
       def set_current_tenant_account
-        tenant_account = MultiTenantSupport::FindTenantAccount.call(
+        tenant_account = find_current_tenant_account
+        MultiTenantSupport::Current.tenant_account = tenant_account
+        instance_variable_set("@#{MultiTenantSupport.current_tenant_account_method}", tenant_account)
+      end
+
+      def find_current_tenant_account
+        MultiTenantSupport::FindTenantAccount.call(
           subdomains: request.subdomains,
           domain: request.domain
         )
-        MultiTenantSupport::Current.tenant_account = tenant_account
-        instance_variable_set("@#{MultiTenantSupport.current_tenant_account_method}", tenant_account)
       end
     end
   end

--- a/lib/multi_tenant_support/concern/controller_concern.rb
+++ b/lib/multi_tenant_support/concern/controller_concern.rb
@@ -20,6 +20,7 @@ module MultiTenantSupport
         instance_variable_set("@#{MultiTenantSupport.current_tenant_account_method}", tenant_account)
       end
 
+      # A user can override this method, if he need a customize way
       def find_current_tenant_account
         MultiTenantSupport::FindTenantAccount.call(
           subdomains: request.subdomains,

--- a/lib/multi_tenant_support/version.rb
+++ b/lib/multi_tenant_support/version.rb
@@ -1,3 +1,3 @@
 module MultiTenantSupport
-  VERSION = '1.0.5'
+  VERSION = '1.1.0'
 end

--- a/test/dummy/app/controllers/user_tags_controller.rb
+++ b/test/dummy/app/controllers/user_tags_controller.rb
@@ -1,0 +1,10 @@
+class UserTagsController < ApplicationController
+  def index
+  end
+
+  private
+
+  def find_current_tenant_account
+    Account.find_by(domain: request.domain)
+  end
+end

--- a/test/dummy/app/views/super_admin/dashboard/show.html.erb
+++ b/test/dummy/app/views/super_admin/dashboard/show.html.erb
@@ -5,6 +5,6 @@
   <div>Current tenant does not exist</div>
 <% end %>
 <div id="UsersCount"><%= User.count %></div>
-<div id="Bezos"><%= User.find_by(email: 'bezos@example.com').name %></div>
-<div id="Zuck"><%= User.find_by(email: 'zuck@example.com').name %></div>
-<div id="Steve"><%= User.find_by(email: 'steve@example.com').name %></div>
+<div id="Bezos"><%= User.find_by(email: 'bezos@example.com')&.name %></div>
+<div id="Zuck"><%= User.find_by(email: 'zuck@example.com')&.name %></div>
+<div id="ve"><%= User.find_by(email: 'steve@example.com')&.name %></div>

--- a/test/dummy/app/views/user_tags/index.html.erb
+++ b/test/dummy/app/views/user_tags/index.html.erb
@@ -1,0 +1,5 @@
+<h1>UserTags#index</h1>
+<div id="id"><%= current_tenant_account.id %></div>
+<div id="name"><%= current_tenant_account.name %></div>
+<div id="domain"><%= current_tenant_account.domain %></div>
+<div id="subdomain"><%= current_tenant_account.subdomain %></div>

--- a/test/dummy/config/routes.rb
+++ b/test/dummy/config/routes.rb
@@ -1,6 +1,7 @@
 Rails.application.routes.draw do
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
   resources :users
+  resources :user_tags
 
   namespace :super_admin do
     resource :dashboard, controller: :dashboard

--- a/test/integration/customize_current_tenant_finder_test.rb
+++ b/test/integration/customize_current_tenant_finder_test.rb
@@ -1,0 +1,40 @@
+require "test_helper"
+
+class CustomizeCurrentTenantFinderTest < ActionDispatch::IntegrationTest
+
+  setup do
+    @amazon = accounts(:amazon)
+  end
+
+  test "find correct tenant with subdomain" do
+    host! "amazon.example.com"
+    get user_tags_path
+
+    assert_redirected_to super_admin_dashboard_path
+    follow_redirect!
+    assert_response :success
+    assert_select "h1", text: "SuperAdmin Dashboard"
+  end
+
+  test "find correct tenant with domain" do
+    host! "amazon.com"
+    get user_tags_path
+
+    assert_response :success
+    assert_select "#id", text: @amazon.id.to_s
+    assert_select "#name", text: "Amazon"
+    assert_select "#domain", text: "amazon.com"
+    assert_select "#subdomain", text: "amazon"
+  end
+
+  test "can't find tenant when visit the host domain" do
+    host! "example.com"
+    get user_tags_path
+
+    assert_redirected_to super_admin_dashboard_path
+    follow_redirect!
+    assert_response :success
+    assert_select "h1", text: "SuperAdmin Dashboard"
+  end
+
+end


### PR DESCRIPTION
Now we can easily change the tenant finding strategy through override `find_current_tenant_account`. Example:

```ruby
class ApplicationController < ActionController::Base
  private

  def find_current_tenant_account
    Account.find_by(domain: request.domain)
  end
end
```